### PR TITLE
tray: implement `draw.Image` using `Pixmap`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module deedles.dev/tray
 
 go 1.24.2
 
-require (
-	deedles.dev/ximage v0.0.0-20250321223218-e433919886dd
-	github.com/godbus/dbus/v5 v5.1.0
-)
+require github.com/godbus/dbus/v5 v5.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,2 @@
-deedles.dev/ximage v0.0.0-20250321223218-e433919886dd h1:idpMQR6xGdQEyl1QshL2TRF8dp9jBJ3ndcn5CdV/YhE=
-deedles.dev/ximage v0.0.0-20250321223218-e433919886dd/go.mod h1:YnxyYpjiUD7yhS14uOWihIJ+GaB6wZFeOk3RwR8p4SM=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/item.go
+++ b/item.go
@@ -369,7 +369,10 @@ type Pixmap struct {
 // convert it to a Pixmap in advance using this function and then pass
 // the result intead of the original image.Image.
 func ToPixmap(img image.Image) Pixmap {
-	if p, ok := img.(Pixmap); ok {
+	switch p := img.(type) {
+	case Pixmap:
+		return p.Copy()
+	case *Pixmap:
 		return p.Copy()
 	}
 

--- a/item.go
+++ b/item.go
@@ -411,11 +411,8 @@ func (p *Pixmap) Set(x, y int, c color.Color) {
 
 // Copy returns a deep copy of p.
 func (p Pixmap) Copy() Pixmap {
-	return Pixmap{
-		Width:  p.Width,
-		Height: p.Height,
-		Data:   slices.Clone(p.Data),
-	}
+	p.Data = slices.Clone(p.Data)
+	return p
 }
 
 // ARGB32 is the color.Color implementation used by [Pixmap].

--- a/tray.go
+++ b/tray.go
@@ -6,7 +6,6 @@
 package tray
 
 import (
-	"encoding/binary"
 	"log/slog"
 	"maps"
 	"os"
@@ -81,37 +80,4 @@ func sliceRemove[S ~[]T, T comparable](s S, v T) S {
 		return s
 	}
 	return slices.Delete(s, i, i+1)
-}
-
-type formatARGB32 struct{}
-
-// ARGB32 is an implementation of [format.Format] that handles the
-// ARBG32 format used by StatusNotifierItem for Pixmap data. It is
-// exported for convenience.
-var ARGB32 formatARGB32
-
-func (formatARGB32) String() string { return "ARGB32" }
-
-func (formatARGB32) Size() int { return 4 }
-
-func (formatARGB32) Read(data []byte) (r, g, b, a uint32) {
-	n := binary.BigEndian.Uint32(data)
-	a = (n >> 24 * 0xFFFF / 0xFF)
-	r = (n >> 16 & 0xFF) * a / 0xFF
-	g = (n >> 8 & 0xFF) * a / 0xFF
-	b = (n & 0xFF) * a / 0xFF
-	return
-}
-
-func (formatARGB32) Write(buf []byte, r, g, b, a uint32) {
-	if a == 0 {
-		copy(buf, []byte{0, 0, 0, 0})
-		return
-	}
-
-	r = (r * 0xFF / a) << 16
-	g = (g * 0xFF / a) << 8
-	b = b * 0xFF / a
-	a = (a * 0xFF / 0xFFFF) << 24
-	binary.BigEndian.PutUint32(buf, r|g|b|a)
 }


### PR DESCRIPTION
This removes the dependency on `deedles.dev/ximage`. It also probably improves performance, but I haven't actually tested it. It does make a nice optimization possible, though, as the user can now pre-convert an image to a Pixmap.